### PR TITLE
Updated to the new luau syntax due to luau's removal of 'declare class' causing many type errors

### DIFF
--- a/.vscode/exploitTypes.d.luau
+++ b/.vscode/exploitTypes.d.luau
@@ -2,14 +2,14 @@
 
 type Function = (...any) -> ...any
 
-declare class DataModel extends DataModel
+declare extern type EDataModel extends DataModel with
 	function HttpGet(self, url: string): string
 	function HttpPost(self, url: string, data: string, contentType: string?): string
 end
 
-declare game: DataModel
+declare game: EDataModel
 
-declare class HttpResponse
+declare extern type HttpResponse with
     Body: string
     StatusCode: number
     StatusMessage: string
@@ -69,7 +69,7 @@ declare function fireclickdetector(object: Instance, distance: number?, event: s
 declare function firetouchinterest(ToTouch: Instance, ThatTouches: number, State0Untouching1Touching: number): ()
 declare function fireproximityprompt(object: ProximityPrompt, distance: number?): ()
 declare function getcallbackvalue(object: Instance, property: string): Function?
-declare class ConnectionGarbage
+declare extern type ConnectionGarbage with
 	Enabled: boolean
 	ForeignState: boolean
 	LuaConnection: boolean
@@ -237,7 +237,7 @@ declare LRM_ScriptVersion: string
 
 -- \\ Drawing // --
 
-declare class DrawEntry
+declare extern type DrawEntry with
 	Visible: boolean
 	Transparency: number
 	Opacity: number
@@ -250,14 +250,14 @@ declare class DrawEntry
 	function MoveToBack(self): nil
 end
 
-declare class LineDrawing extends DrawEntry
+declare extern type LineDrawing extends DrawEntry with
 	Thickness: number
 	From: Vector2
 	To: Vector2
 	Visible: boolean
 end
 
-declare class TextDrawing extends DrawEntry
+declare extern type TextDrawing extends DrawEntry with
 	Text: string
 	TextBounds: Vector2
 	Position: Vector2
@@ -268,7 +268,7 @@ declare class TextDrawing extends DrawEntry
 	OutlineColor3: boolean
 end
 
-declare class ImageDrawing extends DrawEntry
+declare extern type ImageDrawing extends DrawEntry with
 	Data: string
 	ImageSize: Vector2
 	Size: Vector2
@@ -276,7 +276,7 @@ declare class ImageDrawing extends DrawEntry
 	Rounding: number
 end
 
-declare class CircleDrawing extends DrawEntry
+declare extern type CircleDrawing extends DrawEntry with
 	Thickness: number
 	NumSides: number
 	Radius: number
@@ -284,14 +284,14 @@ declare class CircleDrawing extends DrawEntry
 	Position: Vector2
 end
 
-declare class SquareDrawing extends DrawEntry
+declare extern type SquareDrawing extends DrawEntry with
 	Thickness: number
 	Size: Vector2
 	Position: Vector2
 	Filled: boolean
 end
 
-declare class TriangleDrawing extends DrawEntry
+declare extern type TriangleDrawing extends DrawEntry with
 	Thickness: number
 	PointA: Vector2
 	PointB: Vector2
@@ -299,7 +299,7 @@ declare class TriangleDrawing extends DrawEntry
 	Filled: boolean
 end
 
-declare class QuadDrawing extends DrawEntry
+declare extern type QuadDrawing extends DrawEntry with
 	Thickness: number
 	PointA: Vector2
 	PointB: Vector2


### PR DESCRIPTION
Fixed many type errors due to luau's complete removal of 'declare class' syntax, and luau language server's recent update to that version. Replaced it with the new and recommended 'declare extern type' syntax, which can be seen here: https://github.com/luau-lang/luau/releases#release-0.720 and here https://rfcs.luau.org/udtf-is-extern.html


Also, if you dislike the PR's way of making game an "EDataModel" type, thinking that it might break something:
```
declare extern type EDataModel extends DataModel with
	function HttpGet(self, url: string): string
	function HttpPost(self, url: string, data: string, contentType: string?): string
end

declare game: EDataModel
```
This can be used instead:
```
declare game: DataModel & {
    HttpGet: (self: DataModel, url: string) -> string,
    HttpPost: (self: DataModel, url: string, data: string, contentType: string?) -> string,
}
```